### PR TITLE
updating OPF format corpus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "OPF format-corpus"]
 	path = OPF format-corpus
-	url = https://github.com/openplanets/format-corpus.git
+	url = https://github.com/openpreserve/format-corpus.git


### PR DESCRIPTION
closes #6 

This commit updates the OPF submodule to point at github.com/openpreserve, rather than the older githubcom/openplanets and updates the submodule to the most recent commit.