### PR TITLE
Add command for variously encoded directory names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 simple:
 	./createtransfers/createtransfers.py create-variously-encoded-files
 	./createtransfers/createtransfers.py create-deep-transfers
+	./createtransfers/createtransfers.py create-variously-encoded-dir-names
 
 all: simple
 	./createtransfers/createtransfers.py create-large-test-transfers

--- a/createtransfers/createtransfersargs.py
+++ b/createtransfers/createtransfersargs.py
@@ -53,6 +53,13 @@ def get_parser(**kwargs):
             opts=None
         ),
         Subcommand(
+            name=kwargs["CMD_DIRS"],
+            help='Create sample data with variously encoded directory names '
+                 'and strange characters.',
+            args=None,
+            opts=None
+        ),
+        Subcommand(
             name=kwargs["CMD_LARGE"],
             help='Create large transfer sample data.',
             args=None,


### PR DESCRIPTION
This commit adds a new command to leverage the variously encoded filenames tuple to output directories with different encoding as well. So that tests with the new structure are specific to directories, the sample file for the transfer is created with a simple ascii filename that describes which encoding was used for its parent dir. This PR will resolve #34.