### PR TITLE
Avoid capitalization differences in normalization

### DIFF
--- a/TestTransfers/manualNormalization/manualNormalization/normalization.csv
+++ b/TestTransfers/manualNormalization/manualNormalization/normalization.csv
@@ -9,5 +9,5 @@ image_4.gif,manualNormalization/access/image_4_tent/image_4.jpg,manualNormalizat
 image_4.bmp,manualNormalization/access/image_4_flower/image_4.jpg,manualNormalization/preservation/image_4_flower/image_4.png
 image_5.gif,manualNormalization/access/image_5.jpg,
 image_5.bmp,,manualNormalization/preservation/image_5.png
-imaGe_8.gif,manualNormalization/access/image_8.Jpg,manualNormalization/preservation/image_8.tif
-imAge_8.bmp,manualNormalization/access/image_8.pdf,manualNormalization/preservation/image_8.PNG
+image_8.gif,manualNormalization/access/image_8.jpg,manualNormalization/preservation/image_8.tif
+image_8.bmp,manualNormalization/access/image_8.pdf,manualNormalization/preservation/image_8.png

--- a/TestTransfers/manualNormalization/testcase_descriptions.txt
+++ b/TestTransfers/manualNormalization/testcase_descriptions.txt
@@ -45,11 +45,7 @@ O
 7 - manually normalized, but no conflicting original file (not in CSV)
 O,A,P
 
-8 - both manually normalized, CSV has different capitalization
-O,A,P
-O,A,P
-
-9 - manually normalized to subdirectory
+8 - manually normalized to subdirectory
 O,A,
 
 TODO
@@ -57,4 +53,3 @@ TODO
 O,A,P
 O,A,P
 (special characters in name)
-


### PR DESCRIPTION
Files with different capitalization may exists in most of the OS,
therefore the match made for manually normalized transfers in
`manualNormalization/normalization.csv` should be case sensitive.

Connects to https://github.com/archivematica/Issues/issues/331.