### PR TITLE
Add objects directory to ISODiskImage metadata

### DIFF
--- a/SampleTransfers/ISODiskImage/metadata/checksum.md5
+++ b/SampleTransfers/ISODiskImage/metadata/checksum.md5
@@ -1,1 +1,1 @@
-940234538038cd121d9aaddb323a673a  images.iso
+940234538038cd121d9aaddb323a673a  objects/images.iso


### PR DESCRIPTION
This updates the MD5 metadata of `SampleTransfer/ISODiskImage` to include the `objects` directory to avoid this failure in the `Verify metadata directory checksums` job:

```
Comparing transfer checksums with the supplied md5 file
md5: comparison exited with status: 1. Please check the formatting of the checksums or integrity of the files.
md5: images.iso: FAILED open or read
```

Connected to https://github.com/archivematica/Issues/issues/346