### PR TITLE
Add processingMCP transfer to sampledata

### DIFF
--- a/SampleTransfers/ProcessingMCP/processingMCP.xml
+++ b/SampleTransfers/ProcessingMCP/processingMCP.xml
@@ -1,0 +1,3 @@
+<processingMCP>
+  <preconfiguredChoices/>
+</processingMCP>

--- a/SampleTransfers/ProcessingMCP/readme.md
+++ b/SampleTransfers/ProcessingMCP/readme.md
@@ -1,0 +1,5 @@
+## About this transfer
+
+This transfer contains a blank processingMCP.xml file. This should result the
+user being prompted to make a decision at every single decision point,
+over-riding the default processing configuration.


### PR DESCRIPTION
This change adds a very simple transfer containing a blank processingMCP.xml
file to the SampleTransfers. When this transfer is run, all decision
points should be left up to the user, over-riding whatever decisions
have been configured in the default processing config.

Even though it's a pain to process with, I went with a blank processingMCP.xml
because it should, in theory, never change, even if new decision points are added
to Archivematica.