### PR TITLE
Remove some eventOutcomeDetail elements from PremisImporter transfer

### DIFF
--- a/SampleTransfers/PremisImporter/metadata/premis.xml
+++ b/SampleTransfers/PremisImporter/metadata/premis.xml
@@ -83,9 +83,6 @@
     </premis:eventDetailInformation>
     <premis:eventOutcomeInformation>
       <premis:eventOutcome/>
-      <premis:eventOutcomeDetail>
-        <premis:eventOutcomeDetailNote/>
-      </premis:eventOutcomeDetail>
     </premis:eventOutcomeInformation>
     <premis:linkingAgentIdentifier>
       <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>
@@ -104,9 +101,6 @@
     </premis:eventDetailInformation>
     <premis:eventOutcomeInformation>
       <premis:eventOutcome>Pass</premis:eventOutcome>
-      <premis:eventOutcomeDetail>
-        <premis:eventOutcomeDetailNote/>
-      </premis:eventOutcomeDetail>
     </premis:eventOutcomeInformation>
     <premis:linkingAgentIdentifier>
       <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>
@@ -125,9 +119,6 @@
     </premis:eventDetailInformation>
     <premis:eventOutcomeInformation>
       <premis:eventOutcome/>
-      <premis:eventOutcomeDetail>
-        <premis:eventOutcomeDetailNote/>
-      </premis:eventOutcomeDetail>
     </premis:eventOutcomeInformation>
     <premis:linkingAgentIdentifier>
       <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>


### PR DESCRIPTION
This PR removes some optional (and empty) `eventOutcomeDetail` elements from the `premis.xml` file in the `PremisImporter` transfer.

Connected to https://github.com/archivematica/Issues/issues/967