### PR TITLE
Add file for metadata only reingest test

### DIFF
--- a/SampleTransfers/MetadataOnlyReingest/metadata.csv
+++ b/SampleTransfers/MetadataOnlyReingest/metadata.csv
@@ -1,0 +1,3 @@
+filename,dc.title
+objects/bird.mp3,"14000 Caen, France - Bird in my garden REINGESTED"
+objects/beihai.tif,"Beihai, Guanxi, China, 1988 REINGESTED"


### PR DESCRIPTION
This adds a metadata.csv file used in the black-box metadata only reingest scenario added in https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/178

Connected to https://github.com/archivematica/Issues/issues/959