### PR TITLE
Add DC schema to metadata XML AMAUAT catalog

### DIFF
--- a/xml-validation/catalog.xml
+++ b/xml-validation/catalog.xml
@@ -20,6 +20,10 @@
       systemId="http://schemas.opengis.net/gml/3.1.1/smil/smil20.xsd"
       uri="./schemas/catalog/gml/smil/smil20.xsd" />
 
+    <system
+      systemId="http://dublincore.org/schemas/xmls/simpledc20021212.xsd"
+      uri="./schemas/catalog/xmls/simpledc20021212.xsd" />
+
   </group>
 
 </catalog>

--- a/xml-validation/schemas/catalog/xmls/simpledc20021212.xsd
+++ b/xml-validation/schemas/catalog/xmls/simpledc20021212.xsd
@@ -1,0 +1,78 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://purl.org/dc/elements/1.1/"
+           targetNamespace="http://purl.org/dc/elements/1.1/"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation xml:lang="en">
+      Simple DC XML Schema, 2002-10-09
+      by Pete Johnston (p.johnston@ukoln.ac.uk),
+      Carl Lagoze (lagoze@cs.cornell.edu), Andy Powell (a.powell@ukoln.ac.uk),
+      Herbert Van de Sompel (hvdsomp@yahoo.com).
+      This schema defines terms for Simple Dublin Core, i.e. the 15
+      elements from the http://purl.org/dc/elements/1.1/ namespace, with
+      no use of encoding schemes or element refinements.
+      Default content type for all elements is xs:string with xml:lang
+      attribute available.
+
+      Supercedes version of 2002-03-12. 
+      Amended to remove namespace declaration for http://www.w3.org/XML/1998/namespace namespace,
+      and to reference lang attribute via built-in xml: namespace prefix.
+      xs:appinfo also removed.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+             schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+  </xs:import>
+
+  <xs:element name="title" type="elementType"/>
+  <xs:element name="creator" type="elementType"/>
+  <xs:element name="subject" type="elementType"/>
+  <xs:element name="description" type="elementType"/>
+  <xs:element name="publisher" type="elementType"/>
+  <xs:element name="contributor" type="elementType"/>
+  <xs:element name="date" type="elementType"/>
+  <xs:element name="type" type="elementType"/>
+  <xs:element name="format" type="elementType"/>
+  <xs:element name="identifier" type="elementType"/>
+  <xs:element name="source" type="elementType"/>
+  <xs:element name="language" type="elementType"/>
+  <xs:element name="relation" type="elementType"/>
+  <xs:element name="coverage" type="elementType"/>
+  <xs:element name="rights" type="elementType"/>
+
+  <xs:group name="elementsGroup">
+  <xs:sequence>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:element ref="title"/>
+      <xs:element ref="creator"/>
+      <xs:element ref="subject"/>
+      <xs:element ref="description"/>
+      <xs:element ref="publisher"/>
+      <xs:element ref="contributor"/>
+      <xs:element ref="date"/>
+      <xs:element ref="type"/>
+      <xs:element ref="format"/>
+      <xs:element ref="identifier"/>
+      <xs:element ref="source"/>
+      <xs:element ref="language"/>
+      <xs:element ref="relation"/>
+      <xs:element ref="coverage"/>
+      <xs:element ref="rights"/>
+    </xs:choice>
+    </xs:sequence>
+  </xs:group>
+
+  <xs:complexType name="elementType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute ref="xml:lang" use="optional"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>
+
+


### PR DESCRIPTION
The `metadata-xml` AMAUAT tag fails because GitHub requests to `http://dublincore.org/schemas/xmls/simpledc20021212.xsd` are being blocked. This is the output of the `createmets_v2.0` job in the MCPClient:

```console
archivematicaClient.py: INFO      2026-01-22 16:37:56,977  archivematica.mcp.client.job:log_results:81:  #<createmets_v2.0; exit=0; code= uuid=3df61115-9266-49e5-adda-b8acf6204870
=============== STDOUT ===============
Skipping creation of normative structmap
Deleted empty directory /var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/amauat-transfer_1769099844-612caa16-b414-4955-9b66-33c651d9212d/thumbnails
Deleted empty directory /var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/amauat-transfer_1769099844-612caa16-b414-4955-9b66-33c651d9212d/logs/fileMeta
Deleted empty directory /var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/amauat-transfer_1769099844-612caa16-b414-4955-9b66-33c651d9212d/logs/transfers/amauat-transfer_1769099844-a452098d-b231-47a4-bfe4-6992df2be131/logs/fileMeta
METS file subsections counts:
	- dmdSec entries: 12
	- amdSec entries: 52
	- techMD entries: 51
	- rightsMD entries: 0
	- digiprovMD entries: 402
	- sourceMD entries: 1

=============== END STDOUT ===============
=============== STDERR ===============
/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/amauat-transfer_1769099844-612caa16-b414-4955-9b66-33c651d9212d/metadata doesn't exist
Error(s) processing and/or validating XML metadata:
	- Could not parse schema file: file:///src/hack/submodules/archivematica-sampledata/xml-validation/schemas/oai_dc.xsd
	- Space required after the Public Identifier, line 1, column 50

=============== END STDERR ===============
```

This adds a local copy of the `simpledc20021212.xsd` schema to the custom catalog used in XML metadata validation.